### PR TITLE
(repo): Remove git-lfs files

### DIFF
--- a/.github/demo.png
+++ b/.github/demo.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6688c9b4a9e17a148752962f6f66e9e664149b92497f5742f53378d41ecd1193
-size 107933

--- a/README.org
+++ b/README.org
@@ -9,7 +9,7 @@ This package acts as a parallel of [[https://github.com/gagbo/consult-lsp][consu
 interface for the ~workspace/symbols~ LSP procedure call.
 
 #+CAPTION: Obligatory screenshot of consult-eglot in action.
-[[file:.github/demo.png]]
+[[https://user-images.githubusercontent.com/23294780/131529081-7b6ad89a-98c8-40f2-9ef8-184856f8e9ef.png]]
 
 * Table of Contents                                                     :TOC:
 - [[#installation][Installation]]


### PR DESCRIPTION
Fails when git-lfs isn't installed.

Closes #3 