### PR TITLE
Enable input history in symbol search

### DIFF
--- a/consult-eglot.el
+++ b/consult-eglot.el
@@ -181,6 +181,8 @@ rely on regexp matching to extract the relevent file and column fields."
                        (funcall (or open #'find-file) file)
                        line col)))))))
 
+(defvar consult-eglot--history nil)
+
 ;;;###autoload
 (defun consult-eglot-symbols ()
   "Interactively select a symbol from the current workspace."
@@ -200,10 +202,10 @@ rely on regexp matching to extract the relevent file and column fields."
              (consult-eglot--make-async-source server)
              (consult--async-throttle)
              (consult--async-split))
-           :history t
            :require-match t
            :prompt "LSP Symbols: "
            :initial (consult--async-split-initial nil)
+           :history '(:input consult-eglot--history)
            :category 'consult-lsp-symbols
            :lookup #'consult--lookup-candidate
            :group (consult--type-group consult-eglot-narrow)


### PR DESCRIPTION
By defining a variable and passing it in as the `:history` argument to `consult--read`, one can use `M-p` to go back in the history of things entered.